### PR TITLE
💄(templates) add a custom font declaration

### DIFF
--- a/src/backend/instart/templates/richie/base.html
+++ b/src/backend/instart/templates/richie/base.html
@@ -1,0 +1,5 @@
+{% extends "richie/base.html" %}
+
+{% block meta %}
+<link href="https://fonts.googleapis.com/css?family=Raleway:500,500i,700,900&display=swap" rel="stylesheet">
+{% endblock meta %}


### PR DESCRIPTION
## Purpose

We want to declare a custom font. 

## Proposal

This can be done by overriding `{% block meta %}` in the `base.html` template.

:warning: we would prefer to have a dedicated block in the `base.html` template. This must be added to [richie](https://github.com/openfun/richie) first.